### PR TITLE
Prevent returning undefined variable

### DIFF
--- a/src/transports/imap/imap_set.php
+++ b/src/transports/imap/imap_set.php
@@ -221,8 +221,8 @@ class ezcMailImapSet implements ezcMailParserSet
                     }
                     return $data;
                 }
+                return $data;
             }
-            return $data;
         }
         return null;
     }


### PR DESCRIPTION
The $data variable might not be set, this commit makes sure it is only returned when set.